### PR TITLE
Adding setup.py stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/*
 *.pyc
+dist/*
+build/*
+*.egg-info/*
+.venv/*

--- a/rpm_repo_manager/__init__.py
+++ b/rpm_repo_manager/__init__.py
@@ -178,7 +178,7 @@ def load_hardcoded_defaults():
     return config
 
 
-if __name__ == '__main__':
+def main():
     try:
         cli_args = parse_command_line()
         settings = load_config(cli_args['configfile'])
@@ -215,3 +215,5 @@ if __name__ == '__main__':
     event_exit.clear()
 
 # app.run()
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ setup(
     version="0.0.1",
     description="RPM manager",
     author="Sergey Pechenko",
-    author_email="invalid@example.com",
+    author_email="10977752+tnt4brain@users.noreply.github.com",
     url="https://github.com/tnt4brain/rpm-repo-manager",
     packages=find_packages(),
     entry_points="""
         [console_scripts]
         rpm-repo-manager=rpm_repo_manager:main
     """,
-    long_description="""Manage RPM (extend this)"""
+    long_description="""Manages and update RPM repository (requires 'createrepo' to be installed)"""
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+from setuptools import setup, find_packages, Command
+import sys
+
+setup(
+    name="rpm_repo_manager",
+    version="0.0.1",
+    description="RPM manager",
+    author="Sergey Pechenko",
+    author_email="invalid@example.com",
+    url="https://github.com/tnt4brain/rpm-repo-manager",
+    packages=find_packages(),
+    entry_points="""
+        [console_scripts]
+        rpm-repo-manager=rpm_repo_manager:main
+    """,
+    long_description="""Manage RPM (extend this)"""
+)


### PR DESCRIPTION
I've added a minimal stub for setup.py with entry points. After running `python setup.py install` user can call this module by `rpm-repo-manager` name. 

Please fill rest of information inside setup.py and add LICENSE file to clarify copyright.

I waives all claim of copyright (economic and moral) in this commit and immediately places it in the public domain; it may be used, distorted or destroyed or re-attributed under any license in any manner whatsoever without further attribution or notice to the creator.